### PR TITLE
Add right-click and stop key triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ streamlit run app.py
 ```
 
 Tetikleyici tuşu seçip **AYARLA**'ya bastıktan sonra uygulama açık kalırken
-başka bir pencerede seçilen tuşa basarak sol tıklamayı saniyede 15 kez
-başlatıp durdurabilirsiniz.
+başka bir pencerede seçilen tuşlara basarak sol veya sağ tıklamayı saniyede 15 kez
+başlatıp durdurabilirsiniz. Ayrıca belirlediğiniz durdurma tuşu uygulamayı
+tamamen kapatır.


### PR DESCRIPTION
## Summary
- allow configuring separate keys for left and right auto-clicking
- add key to exit the application entirely
- document new controls in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0c3c6349c832f92f644fdf8187b91