### PR TITLE
Allow resume after stop key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ streamlit run app.py
 
 Tetikleyici tuşu seçip **AYARLA**'ya bastıktan sonra uygulama açık kalırken
 başka bir pencerede seçilen tuşlara basarak sol veya sağ tıklamayı saniyede 15 kez
-başlatıp durdurabilirsiniz. Ayrıca belirlediğiniz durdurma tuşu uygulamayı
-tamamen kapatır.
+başlatıp durdurabilirsiniz. Ayrıca belirlediğiniz durdurma tuşu tıklamaları
+sonlandırır.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,3 @@
-import os
 import threading
 import time
 
@@ -34,7 +33,7 @@ def clicker() -> None:
 
 
 def on_press(key: keyboard.Key) -> None:
-    """Toggle clicking or exit based on the pressed key."""
+    """Toggle clicking or stop based on the pressed key."""
     global left_clicking, right_clicking, left_trigger_key, right_trigger_key, stop_key
     try:
         if key.char:
@@ -46,7 +45,6 @@ def on_press(key: keyboard.Key) -> None:
             elif k == stop_key:
                 left_clicking = False
                 right_clicking = False
-                os._exit(0)
     except AttributeError:
         # Ignore special keys
         pass
@@ -65,7 +63,7 @@ def main() -> None:
     st.write(
         "Sol ve sağ tıklamalar için tuşları seçip AYARLA'ya basın. Uygulama açıkken "
         "seçilen tuşlara basarak tıklamayı başlatıp durdurabilirsiniz. Durdurma tuşu "
-        "uygulamayı tamamen kapatır."
+        "tıklamaları sonlandırır."
     )
 
     left_key_input = st.text_input(


### PR DESCRIPTION
## Summary
- Stop key now halts clicking without exiting so the app can resume
- Update documentation to describe new stop behavior

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0c517c9b0832fa734bde0fd5b67e1