### PR TITLE
Add pause key and key combination support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ streamlit run app.py
 Tetikleyici tuşu seçip **AYARLA**'ya bastıktan sonra uygulama açık kalırken
 başka bir pencerede seçilen tuşlara basarak sol veya sağ tıklamayı saniyede 15 kez
 başlatıp durdurabilirsiniz. Ayrıca belirlediğiniz durdurma tuşu tıklamaları
-sonlandırır.
+sonlandırır. İsteğe bağlı olarak duraklatma tuşu ile tetikleyicileri geçici olarak
+devre dışı bırakabilir ve tek tuş yerine `ctrl+p` gibi kombinasyonlar atayabilirsiniz.


### PR DESCRIPTION
## Summary
- add configurable pause key to temporarily disable click triggers
- allow assigning key combinations like `ctrl+p` for all triggers
- document new pause and combo features

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0c8eae9d0832fad7ff5b3838bd50c