### PR TITLE
Exit on stop hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ streamlit run app.py
 
 Tetikleyici tuşu seçip **AYARLA**'ya bastıktan sonra uygulama açık kalırken
 başka bir pencerede seçilen tuşlara basarak sol veya sağ tıklamayı saniyede 15 kez
-başlatıp durdurabilirsiniz. Ayrıca belirlediğiniz durdurma tuşu tıklamaları
+başlatıp durdurabilirsiniz. Ayrıca belirlediğiniz durdurma tuşu uygulamayı
 sonlandırır. İsteğe bağlı olarak duraklatma tuşu ile tetikleyicileri geçici olarak
 devre dışı bırakabilir ve tek tuş yerine `ctrl+p` gibi kombinasyonlar atayabilirsiniz.

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import os
 
 import streamlit as st
 from pynput import keyboard
@@ -82,9 +83,8 @@ def on_press(key: keyboard.Key) -> None:
         right_clicking = not right_clicking
         combo_active["right"] = True
     if stop_combo <= pressed_keys and not combo_active["stop"]:
-        left_clicking = False
-        right_clicking = False
         combo_active["stop"] = True
+        os._exit(0)
     if pause_combo <= pressed_keys and not combo_active["pause"]:
         paused = not paused
         left_clicking = False


### PR DESCRIPTION
## Summary
- ensure pressing the stop key combo terminates the application using `os._exit(0)`
- document that the stop key now closes the app

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0cbc88a40832faa168c1fef2950b2