### PR TITLE
Add standalone build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+build/
+dist/
+*.spec

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ başka bir pencerede seçilen tuşlara basarak sol veya sağ tıklamayı saniyed
 başlatıp durdurabilirsiniz. Ayrıca belirlediğiniz durdurma tuşu uygulamayı
 sonlandırır. İsteğe bağlı olarak duraklatma tuşu ile tetikleyicileri geçici olarak
 devre dışı bırakabilir ve tek tuş yerine `ctrl+p` gibi kombinasyonlar atayabilirsiniz.
+
+## Paketleme
+
+Arkadaşınızın herhangi bir kurulum yapmadan çalıştırabileceği tek dosyalık bir sürüm oluşturmak için:
+
+```bash
+pip install -r requirements.txt
+python build.py
+```
+
+Bu komutlar çalıştırıldığında `dist/sol_klik` (Windows'ta `dist/sol_klik.exe`) dosyası oluşur.
+Bu dosyayı hedef işletim sistemiyle aynı platformda paketlemeli ve karşı tarafa göndererek sadece çift tıklayarak çalıştırmasını sağlayabilirsiniz.

--- a/build.py
+++ b/build.py
@@ -1,0 +1,9 @@
+import PyInstaller.__main__
+
+if __name__ == "__main__":
+    PyInstaller.__main__.run([
+        "app.py",
+        "--name=sol_klik",
+        "--onefile",
+        "--noconsole",
+    ])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 streamlit
 pynput
+
+pyinstaller


### PR DESCRIPTION
## Summary
- add PyInstaller-based build script for single-file distribution
- document packaging process and add PyInstaller to requirements
- ignore build artifacts in version control

## Testing
- `pip install -r requirements.txt`
- `python build.py`

------
https://chatgpt.com/codex/tasks/task_b_68b0cca5b488832fbc70aefd8c4fd9b6