### PR TITLE
Include Streamlit metadata in PyInstaller build

### DIFF
--- a/build.py
+++ b/build.py
@@ -6,4 +6,5 @@ if __name__ == "__main__":
         "--name=sol_klik",
         "--onefile",
         "--noconsole",
+        "--copy-metadata=streamlit",
     ])


### PR DESCRIPTION
## Summary
- ensure Streamlit's dist-info metadata is bundled when building the executable

## Testing
- `python -m py_compile app.py build.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0d1ae9e40832fb9c38391f5b74a83