### PR TITLE
Fix Streamlit entry and keep console open

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,6 +162,14 @@ def main() -> None:
         t = threading.Thread(target=clicker, daemon=True)
         t.start()
         st.session_state.clicker_thread = t
-
+    
 if __name__ == "__main__":
-    main()
+    import sys
+    import streamlit as st
+    from streamlit.web import cli as stcli
+
+    if st._is_running_with_streamlit:
+        main()
+    else:
+        sys.argv = ["streamlit", "run", __file__]
+        sys.exit(stcli.main())

--- a/build.py
+++ b/build.py
@@ -5,6 +5,5 @@ if __name__ == "__main__":
         "app.py",
         "--name=sol_klik",
         "--onefile",
-        "--noconsole",
         "--copy-metadata=streamlit",
     ])


### PR DESCRIPTION
## Summary
- Add Streamlit CLI bootstrap so executable launches correctly
- Remove `--noconsole` from build script while keeping Streamlit metadata

## Testing
- `python -m py_compile app.py build.py`
- `python build.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0d598ab60832fb4281cb687f63dad