### PR TITLE
Handle missing Streamlit runtime flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     import streamlit as st
     from streamlit.web import cli as stcli
 
-    if st._is_running_with_streamlit:
+    if getattr(st, "_is_running_with_streamlit", False):
         main()
     else:
         sys.argv = ["streamlit", "run", __file__]


### PR DESCRIPTION
## Summary
- Avoid AttributeError when `_is_running_with_streamlit` is missing.

## Testing
- `pytest`
- `timeout 5 python app.py` *(fails: this platform is not supported)*

------
https://chatgpt.com/codex/tasks/task_b_68b0e0a032bc832f976832d693e07f74