### PR TITLE
Improve Streamlit entrypoint and PyInstaller packaging

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,9 +1,15 @@
+import os
 import PyInstaller.__main__
 
+
 if __name__ == "__main__":
+    sep = ";" if os.name == "nt" else ":"
     PyInstaller.__main__.run([
         "app.py",
         "--name=sol_klik",
         "--onefile",
+        f"--add-data=app.py{sep}.",
+        "--hidden-import=streamlit.web.cli",
+        "--hidden-import=streamlit.cli",
         "--copy-metadata=streamlit",
     ])


### PR DESCRIPTION
## Summary
- Replace legacy entry block with Streamlit/EXE compatible bootstrap
- Update build script to bundle app.py and expose Streamlit CLI for PyInstaller

## Testing
- `python -m py_compile app.py build.py`
- `python build.py`

------
https://chatgpt.com/codex/tasks/task_b_68b0e24188d4832f8e42c55bac31290e