### PR TITLE
Disable Streamlit dev mode and document Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,13 @@ python build.py
 
 Bu komutlar çalıştırıldığında `dist/sol_klik` (Windows'ta `dist/sol_klik.exe`) dosyası oluşur.
 Bu dosyayı hedef işletim sistemiyle aynı platformda paketlemeli ve karşı tarafa göndererek sadece çift tıklayarak çalıştırmasını sağlayabilirsiniz.
+
+Windows'ta doğrudan PyInstaller komutu kullanmak isterseniz:
+
+```powershell
+pyinstaller app.py --onefile --name PoyrazClicker `
+  --collect-metadata streamlit --collect-data streamlit `
+  --hidden-import streamlit.web.cli `
+  --add-data "app.py;app.py" `
+  --console
+```

--- a/app.py
+++ b/app.py
@@ -187,7 +187,14 @@ def _run_via_streamlit_cli():
     else:
         script_path = os.path.abspath(__file__)
 
-    sys.argv = ["streamlit", "run", script_path, "--server.headless=true"]
+    sys.argv = [
+        "streamlit",
+        "run",
+        script_path,
+        "--browser.serverAddress=localhost",
+        "--browser.serverPort=8501",
+        "--global.developmentMode=false",
+    ]
     raise SystemExit(stcli.main())
 
 


### PR DESCRIPTION
## Summary
- Disable Streamlit development mode and specify server host/port when launching from packaged app
- Document Windows PyInstaller command for building a standalone executable

## Testing
- `python -m py_compile app.py`
- `python -m py_compile build.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0f835dfa0832fb70dca45ffe57686